### PR TITLE
changed "params" argument to "data" in request to oauth2/token for hostedui authentication

### DIFF
--- a/src/streamlit_cognito_auth/auth.py
+++ b/src/streamlit_cognito_auth/auth.py
@@ -607,8 +607,8 @@ class CognitoHostedUIAuthenticator(CognitoAuthenticatorBase):
             "Content-Type": "application/x-www-form-urlencoded",
             "Authorization": f"Basic {secret_hash}"
         }
-        resp = requests.post(token_url, params=payload, headers=headers)
-
+        resp = requests.post(token_url, data=payload, headers=headers)
+    
         if resp.status_code == requests.codes.bad_request:
             raise TokenVerificationException("Invalid authorization code: " + resp.text)
         else:


### PR DESCRIPTION
Fixed bug where oauth flow would return response 400: bad request due to payload being sent as URL parameters instead of form data.